### PR TITLE
Use https for remote target by default.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -7,7 +7,7 @@
            sync-j="4" />
 
   <remote  name="github"
-           fetch="git://github.com/android-ia/" />
+           fetch="https://github.com/android-ia/" />
 
   <remote name="kernelorg" fetch="https://git.kernel.org/" />
 


### PR DESCRIPTION
This helps in anonymous repo sync behind firewalls to work well where
shh port 22 is not opened.

Signed-off-by: Shobhit Kumar <shobhit.kumar@intel.com>