### PR TITLE
packages/apps/Music: fix permission issues

### DIFF
--- a/include/aosp_vanilla.xml
+++ b/include/aosp_vanilla.xml
@@ -411,7 +411,7 @@
   <project groups="aosp,pdk-fs" name="platform/packages/apps/LegacyCamera" path="packages/apps/LegacyCamera"/>
   <project groups="aosp,pdk-fs" name="platform/packages/apps/ManagedProvisioning" path="packages/apps/ManagedProvisioning"/>
   <project groups="aosp,pdk-fs" name="platform/packages/apps/Messaging" path="packages/apps/Messaging"/>
-  <project groups="aosp,pdk-fs" name="platform/packages/apps/Music" path="packages/apps/Music"/>
+  <project groups="aosp,pdk-fs" name="platform/packages/apps/Music" path="packages/apps/Music" revision="master"/>
   <project groups="aosp,pdk-fs" name="platform/packages/apps/MusicFX" path="packages/apps/MusicFX"/>
   <project groups="aosp,apps_nfc,pdk-fs" name="platform/packages/apps/Nfc" path="packages/apps/Nfc"/>
   <project groups="aosp,pdk-fs" name="platform/packages/apps/OneTimeInitializer" path="packages/apps/OneTimeInitializer"/>


### PR DESCRIPTION
Known bug in N fixed in AOSP master by 6036ce61270 ("music: Remove deprecated MODE_WORLD_READABLE and MODE_WORLD_WRITEABLE")

rather than cloning the repository we use the master branch.
This change will have to be removed when moving to O

JIRA: https://01.org/jira/browse/AIA-208
Test: Music app does not crash on startup

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>